### PR TITLE
Bug fix in impact module

### DIFF
--- a/chama/impact.py
+++ b/chama/impact.py
@@ -249,6 +249,7 @@ def detection_times_to_coverage(detection_times, coverage_type='scenario',
         df.drop(['Detection Time Idx', 'Detection Time'], inplace=True, axis=1)
         new_scenario = df.copy()
         new_scenario.drop(['Sensor'], inplace=True, axis=1)
+        new_scenario.drop_duplicates(inplace=True)
 
         # group all the scenarios for each sensor into a list
         coverage = \

--- a/chama/tests/test_impact.py
+++ b/chama/tests/test_impact.py
@@ -145,12 +145,12 @@ class TestConversions(unittest.TestCase):
             'Scenario': ['S1', 'S2', 'S3'],
             'Sensor': ['A', 'A', 'B'],
             'Impact': [2, 3, 4]})
-        
+
         self.scenario = pd.DataFrame({
             'Scenario': ['S1', 'S2', 'S3'],
             'Undetected Impact': [48.0, 250.0, 100.0],
             'Probability': [0.1, 0.1, 0.8]})
-    
+
     @classmethod
     def tearDownClass(self):
         pass
@@ -161,15 +161,14 @@ class TestConversions(unittest.TestCase):
         print(stats)
         assert_equal(stats.loc['S1', 'Mean'], 3)
         assert_equal(stats.loc['S1', 'Max'], 4)
-        
+
     def test_detection_times_to_coverage(self):
-        
         coverage1 = chama.impact.detection_times_to_coverage(
-                detection_times=self.detection_times, coverage_type='scenario')
+            detection_times=self.detection_times, coverage_type='scenario')
         coverage1_expected = pd.DataFrame({'Sensor': ['A', 'B'],
                                            'Coverage': [['S1', 'S2'], ['S3']]
                                            })
-        assert_frame_equal(coverage1.set_index('Sensor'), 
+        assert_frame_equal(coverage1.set_index('Sensor'),
                            coverage1_expected.set_index('Sensor'))
 
         coverage2 = \
@@ -180,13 +179,13 @@ class TestConversions(unittest.TestCase):
                                            'Coverage': [['S1-2.0', 'S1-3.0',
                                                          'S1-4.0', 'S2-3.0'],
                                                         ['S3-4.0', 'S3-5.0']]})
-        assert_frame_equal(coverage2.set_index('Sensor'), 
+        assert_frame_equal(coverage2.set_index('Sensor'),
                            coverage2_expected.set_index('Sensor'))
 
         coverage3, scenario3 = chama.impact.detection_times_to_coverage(
-                detection_times=self.detection_times,
-                coverage_type='scenario-time',
-                scenario=self.scenario)
+            detection_times=self.detection_times,
+            coverage_type='scenario-time',
+            scenario=self.scenario)
         scenario3_expected = pd.DataFrame({'Scenario': ['S1-2.0', 'S1-3.0',
                                                         'S1-4.0', 'S2-3.0',
                                                         'S3-4.0', 'S3-5.0'],
@@ -195,9 +194,9 @@ class TestConversions(unittest.TestCase):
                                                                  100.0, 100.0],
                                            'Probability': [0.1, 0.1, 0.1,
                                                            0.1, 0.8, 0.8]})
-        assert_frame_equal(coverage3.set_index('Sensor'), 
+        assert_frame_equal(coverage3.set_index('Sensor'),
                            coverage2_expected.set_index('Sensor'))
-        assert_frame_equal(scenario3.set_index('Scenario'), 
+        assert_frame_equal(scenario3.set_index('Scenario'),
                            scenario3_expected.set_index('Scenario'))
 
     def test_impact_to_coverage(self):
@@ -207,3 +206,63 @@ class TestConversions(unittest.TestCase):
                                            })
         assert_frame_equal(coverage1.set_index('Sensor'), 
                            coverage1_expected.set_index('Sensor'))
+
+
+    def test_detection_times_to_coverage_duplicates(self):
+        detection_times = pd.DataFrame({
+            'Scenario': ['S1', 'S2', 'S3', 'S1'],
+            'Sensor': ['A', 'A', 'B', 'B'],
+            'Detection Times': [[2, 3, 4], [3], [4, 5], [4, 5]]})
+        impact = pd.DataFrame({
+            'Scenario': ['S1', 'S2', 'S3', 'S1'],
+            'Sensor': ['A', 'A', 'B', 'B'],
+            'Impact': [2, 3, 4, 4]})
+
+        scenario = pd.DataFrame({
+            'Scenario': ['S1', 'S2', 'S3'],
+            'Undetected Impact': [48.0, 250.0, 100.0],
+            'Probability': [0.1, 0.1, 0.8]})
+
+        coverage1 = chama.impact.detection_times_to_coverage(
+            detection_times=detection_times, coverage_type='scenario')
+        coverage1_expected = pd.DataFrame({'Sensor': ['A', 'B'],
+                                           'Coverage': [['S1', 'S2'],
+                                                        ['S3', 'S1']]
+                                           })
+        assert_frame_equal(coverage1.set_index('Sensor'),
+                           coverage1_expected.set_index('Sensor'))
+
+        coverage2 = \
+            chama.impact.detection_times_to_coverage(
+                detection_times=detection_times,
+                coverage_type='scenario-time')
+        coverage2_expected = pd.DataFrame({'Sensor': ['A', 'B'],
+                                           'Coverage': [['S1-2.0', 'S1-3.0',
+                                                         'S1-4.0', 'S2-3.0'],
+                                                        ['S3-4.0', 'S3-5.0',
+                                                         'S1-4.0', 'S1-5.0'
+                                                         ]]})
+        assert_frame_equal(coverage2.set_index('Sensor'),
+                           coverage2_expected.set_index('Sensor'))
+
+        coverage3, scenario3 = chama.impact.detection_times_to_coverage(
+            detection_times=detection_times,
+            coverage_type='scenario-time',
+            scenario=scenario)
+        scenario3_expected = pd.DataFrame({'Scenario': ['S1-2.0', 'S1-3.0',
+                                                        'S1-4.0', 'S2-3.0',
+                                                        'S3-4.0', 'S3-5.0',
+                                                        'S1-5.0'],
+                                           'Undetected Impact': [48.0, 48.0,
+                                                                 48.0, 250.0,
+                                                                 100.0,
+                                                                 100.0,
+                                                                 48.0],
+                                           'Probability': [0.1, 0.1, 0.1,
+                                                           0.1, 0.8, 0.8,
+                                                           0.1]})
+        assert_frame_equal(coverage3.set_index('Sensor'),
+                           coverage2_expected.set_index('Sensor'))
+        assert_frame_equal(scenario3.set_index('Scenario'),
+                           scenario3_expected.set_index('Scenario'))
+

--- a/documentation/impact.rst
+++ b/documentation/impact.rst
@@ -113,7 +113,7 @@ The detection times DataFrame can be converted into the required input
 format for the :ref:`impactform` or :ref:`coverageform` as described below.
 
 Convert detection times to input for the Impact Formulation
-------------------------------------------------------------------
+-----------------------------------------------------------
 The :ref:`impactform` requires as input
 a DataFrame with three columns: 'Scenario', 'Sensor', and 'Impact', where
 the 'Impact' is a single numerical value for each row. This means that the
@@ -121,7 +121,7 @@ list of detection times in the DataFrame produced above must be reduced to a
 single numerical value representing the impact to be minimized.
 
 Minimum detection time
-...............................................
+......................
 
 The example below shows how to build an input DataFrame for the :ref:`impactform` to
 optimize a sensor layout that minimizes detection time.
@@ -162,7 +162,7 @@ Extract the minimum detection time from the statistics computed above:
     8       S3      C      20
 
 Other impact metrics
-...............................................
+....................
 Depending on the information available from the simulation, detection time
 can be converted to other measures of impact, such as damage cost, extent of
 contamination, or ability to protect critical assets and populations. For
@@ -231,7 +231,7 @@ Note that the
 function interpolates based on time, if needed. 
 
 Convert detection times to input for the Coverage Formulation
--------------------------------------------------------------------
+-------------------------------------------------------------
 The :ref:`coverageform` requires as input
 a DataFrame with two columns: 'Sensor', and 'Coverage', where the 'Coverage' is
 a list of entities covered by each sensor. The formulation optimizes a sensor
@@ -241,7 +241,7 @@ An `entity` to be covered might include scenarios, scenario-time pairs, or
 geographic locations. 
 
 Scenario coverage
-...............................................
+.................
 The following example converts detection times to scenario coverage. 
 With `scenario` coverage, a scenario is the entity to be covered. A scenario
 is considered covered by a sensor if that sensor detects that scenario at
@@ -278,7 +278,7 @@ This example shows that sensor A covers the scenarios S1, S2, and S3.
 Sensors B and C also cover all three scenarios.
 
 Scenario-time coverage
-...............................................
+......................
 
 The next example converts detection times to scenario-time coverage. 
 With `scenario-time` coverage, the entities to be covered are all combinations
@@ -330,27 +330,17 @@ information to new scenario-time pairs:
     >>> print(new_scenario)
        Scenario  Probability  Undetected Impact
     0   S1-30.0         0.25                100
-    1   S1-30.0         0.25                100
     2   S1-10.0         0.25                100
     3   S1-20.0         0.25                100
-    4   S1-30.0         0.25                100
     5   S1-40.0         0.25                100
     6   S2-10.0         0.50                100
     7   S2-20.0         0.50                100
     8   S2-30.0         0.50                100
-    9   S2-20.0         0.50                100
-    10  S2-30.0         0.50                100
-    11  S2-10.0         0.50                100
-    12  S2-20.0         0.50                100
-    13  S2-30.0         0.50                100
     14  S2-40.0         0.50                100
     15  S3-20.0         0.75                100
     16  S3-30.0         0.75                100
-    17  S3-20.0         0.75                100
-    18  S3-30.0         0.75                100
-    19  S3-20.0         0.75                100
-    20  S3-30.0         0.75                100
     21  S3-40.0         0.75                100
+
 
 This example shows that sensor A covers the scenario-time pairs S1-30.0,
 S2-10.0, and S2-20.0 among others. In addition, notice that the probability
@@ -358,7 +348,7 @@ and undetected impact for scenario S1 is propagated to all scenario-time
 pairs containing S1 in the new_scenario DataFrame.
 
 Convert input for the Impact Formulation to the Coverage Formulation
-----------------------------------------------------------------------
+--------------------------------------------------------------------
 Users can also convert the input DataFrame for the :ref:`imapctform`
 to the input DataFrame for the :ref:`coverageform`. This is
 especially convenient in cases where the user is solving optimization


### PR DESCRIPTION
This fixes a bug in `detection_times_to_coverage` where the scenario dataframe returned for 'scenario-time' coverage had duplicate scenarios. This PR also adds a test for this case and updates the documentation.