### PR TITLE
Updated GitHub Action workflows and limited Pandas to < 3.0

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -11,7 +11,7 @@ jobs:
     name: Build the documentation with Sphinx
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - run: git fetch origin main
@@ -19,7 +19,7 @@ jobs:
         run: |
           git branch
           git remote -v
-      - uses: actions/setup-python@v2
+      - uses: actions/setup-python@v5
         with: 
           python-version: '3.12'
       - name: Install package
@@ -29,7 +29,7 @@ jobs:
       - name: Build documentation
         run: sphinx-build documentation/ documentation/_build/html
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v4
         with:
           path: 'documentation/_build/html'
 
@@ -46,7 +46,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup Pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v5
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v1
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -21,7 +21,7 @@ jobs:
           git remote -v
       - uses: actions/setup-python@v2
         with: 
-          python-version: '3.11'
+          python-version: '3.12'
       - name: Install package
         run: |
           pip install -e .

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -81,6 +81,7 @@ jobs:
       matrix:
         python-version: ['3.10', '3.11', '3.12', '3.13']
         os: [ubuntu-latest]
+      fail-fast: false
     steps:
     - uses: actions/checkout@v4
     - name: Setup conda
@@ -110,6 +111,7 @@ jobs:
       with:
         name: .coverage.${{ matrix.python-version }}.${{ matrix.os }}
         path: .coverage.${{ matrix.python-version }}.${{ matrix.os }}
+        include-hidden-files: true
 
   combine_reports:
     needs: [ run_coverage ]
@@ -118,19 +120,21 @@ jobs:
     - name: Set up Python 
       uses: actions/setup-python@v5
       with:
-        python-version: 3.12
+        python-version: 3.11
     - uses: actions/checkout@v4
     - name: Install coverage
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements.txt
-        pip install coveralls
         python -m pip install -e .
+        pip install coveralls
     - name: Download coverage artifacts from test matrix
       uses: actions/download-artifact@v4
       with:
-        name: coverage
+        pattern: .coverage.*.ubuntu-latest # coverage from other OS cause problems
     - name: Setup coverage and combine reports
+      run: coverage combine .coverage.*.ubuntu-latest
+    - name: Create coverage report
       run: |
         echo "[paths]" > .coveragerc
         echo "source = " >> .coveragerc
@@ -139,9 +143,7 @@ jobs:
         echo "    D:\\a\\chama\\chama\\chama" >> .coveragerc
         echo "    /home/runner/work/chama/chama/chama" >> .coveragerc
         echo "    /Users/runner/work/chama/chama/chama" >> .coveragerc
-        coverage combine
-    - name: Create coverage report
-      run: |
+        echo "    ${{ github.workspace }}/chama" >> .coveragerc
         coverage report
         coverage json --pretty-print
         coverage html --show-contexts

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -28,9 +28,14 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v4
     - name: Build wheels
-      uses: pypa/cibuildwheel@v3.1.4
-      env:
-        CIBW_BUILD: cp310-* cp311-* cp312-* cp313-*
+      run: |
+        python setup.py bdist_wheel
+        ls dist/*
+    - name: Save wheel
+      uses: actions/upload-artifact@v3
+      with:
+        name: chama_${{ matrix.python-version }}_${{ matrix.os }}.whl
+        path: dist/chama*
     - name: Set up Python for twine verification
       uses: actions/setup-python@v5
       with:
@@ -47,7 +52,7 @@ jobs:
     - name: Upload wheels
       uses: actions/upload-artifact@v4
       with:
-        name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
+        name: chama_${{ matrix.python-version }}_${{ matrix.os }}.whl
         path: ./wheelhouse/*.whl
 
   test_wheels:
@@ -67,7 +72,7 @@ jobs:
     - name: Download wheel
       uses: actions/download-artifact@v4
       with:
-        pattern: "cibw-wheels-*"
+        name: chama_${{ matrix.python-version }}_${{ matrix.os }}.whl
         merge-multiple: true
     - name: Install chama
       run: |

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -67,12 +67,13 @@ jobs:
     - name: Download wheel
       uses: actions/download-artifact@v4
       with:
-        name: chama_${{ matrix.python-version }}_${{ matrix.os }}.whl
+        #name: chama_${{ matrix.python-version }}_${{ matrix.os }}.whl
+        pattern: "chama_*"
         merge-multiple: true
     - name: Install chama
       run: |
         python -m pip install --upgrade pip
-        pip install wheel pyomo pandas<3.0 numpy>2.0 scipy setuptools
+        pip install wheel pyomo "pandas<3.0" "numpy>2.0" scipy setuptools
         pip install --no-index --pre --find-links=. chama
     - name: Import chama
       run: |

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -162,7 +162,7 @@ jobs:
         pip install -r requirements.txt
         python -m pip install -e .
     - name: Download coverage artifacts from test matrix
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: coverage
     - name: Setup coverage and combine reports

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -15,41 +15,47 @@ on:
     
 jobs:
 
-  build:
+  build_wheels:
+    name: Build wheels
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
+      
         python-version: ['3.10', '3.11', '3.12', '3.13']
         os: [ubuntu-latest]
+      fail-fast: false
     steps:
-    - uses: actions/checkout@v4
-    - name: Set up Python
+    - name: Checkout repository
+      uses: actions/checkout@v4
+    - name: Set up Python for twine verification
       uses: actions/setup-python@v5
       with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install dependencies
+        python-version: '3.11'
+    - name: Install twine and verify wheels
+      shell: bash
       run: |
-        python --version
         python -m pip install --upgrade pip
-        pip install wheel
-        pip install -r requirements.txt
-    - name: Build wheel
-      run: |
-        python setup.py bdist_wheel
-        ls dist/*
-    - name: Save wheel
+        pip install twine
+        for wheel in ./wheelhouse/*.whl; do
+          echo "Verifying wheel: $wheel"
+          twine check "$wheel"
+        done
+
+    - name: Upload wheels
       uses: actions/upload-artifact@v4
       with:
-        name: chama_${{ matrix.python-version }}_${{ matrix.os }}.whl
-        path: dist/chama*
+        name: cibw-wheels-${{ matrix.os }}-${{ strategy.job-index }}
+        path: ./wheelhouse/*.whl
 
-  install_import:
-    needs: build
+  test_wheels:
+    name: Test wheels
+    needs: build_wheels
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         python-version: ['3.10', '3.11', '3.12', '3.13']
         os: [ubuntu-latest]
+      fail-fast: false
     steps:
     - name: Set up Python 
       uses: actions/setup-python@v5
@@ -57,6 +63,11 @@ jobs:
         python-version: ${{ matrix.python-version }}
     - name: Download wheel
       uses: actions/download-artifact@v4
+      with:
+        pattern: "cibw-wheels-*"
+        merge-multiple: true
+    - name: Install chama
+      run: |
         python -m pip install --upgrade pip
         pip install wheel pyomo pandas<3.0 numpy>2.0 scipy
         pip install --no-index --pre --find-links=. chama
@@ -64,7 +75,7 @@ jobs:
       run: |
         python -c "import chama"
 
-  pytest_coverage:
+  run_coverage:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -86,7 +97,7 @@ jobs:
         conda install -y -c conda-forge glpk
         pip install coverage coveralls wntr
         python -m pip install -e .
-    - name: Run tests and coverage
+    - name: Run Tests
       run: |
         export PATH=/usr/share/miniconda/bin:$PATH
         coverage erase
@@ -97,11 +108,11 @@ jobs:
     - name: Save coverage
       uses: actions/upload-artifact@v4
       with:
-        name: coverage
+        name: .coverage.${{ matrix.python-version }}.${{ matrix.os }}
         path: .coverage.${{ matrix.python-version }}.${{ matrix.os }}
 
-  coverage_reports:
-    needs: [ pytest_coverage ]
+  combine_reports:
+    needs: [ run_coverage ]
     runs-on: ubuntu-latest
     steps:
     - name: Set up Python 
@@ -115,7 +126,7 @@ jobs:
         pip install -r requirements.txt
         pip install coveralls
         python -m pip install -e .
-    - name: Download coverage artifacts
+    - name: Download coverage artifacts from test matrix
       uses: actions/download-artifact@v4
       with:
         name: coverage
@@ -137,46 +148,14 @@ jobs:
     - name: Save coverage JSON
       uses: actions/upload-artifact@v4
       with:
-        name: coverage
+        name: coverage-json
         path: coverage.json
     - name: Save coverage html
       uses: actions/upload-artifact@v4
       with:
-        name: coverage
+        name: coverage-html
         path: htmlcov
-
-  coveralls:
-    needs: [ pytest_coverage ]
-    runs-on: ubuntu-latest
-    continue-on-error: true
-    steps:
-    - name: Set up Python 
-      uses: actions/setup-python@v5
-      with:
-        python-version: 3.12
-    - uses: actions/checkout@v4
-    - name: Install coverage
-      run: |
-        python -m pip install --upgrade pip
-        pip install coveralls
-        pip install -r requirements.txt
-        python -m pip install -e .
-    - name: Download coverage artifacts from test matrix
-      uses: actions/download-artifact@v4
-      with:
-        name: coverage
-    - name: Setup coverage and combine reports
-      run: |
-        echo "[paths]" > .coveragerc
-        echo "source = " >> .coveragerc
-        echo "    chama/" >> .coveragerc
-        echo "    chama\\" >> .coveragerc
-        echo "    D:\\a\\chama\\chama\\chama" >> .coveragerc
-        echo "    /home/runner/work/chama/chama/chama" >> .coveragerc
-        echo "    /Users/runner/work/chama/chama/chama" >> .coveragerc
-        coverage combine
     - name: Push to coveralls
-      run: |
-        coveralls --service=github
+      run: coveralls --service=github --rcfile=.coveragerc
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -49,11 +49,6 @@ jobs:
           echo "Verifying wheel: $wheel"
           twine check "$wheel"
         done
-    - name: Upload wheels
-      uses: actions/upload-artifact@v4
-      with:
-        name: chama_${{ matrix.python-version }}_${{ matrix.os }}.whl
-        path: dist/chama*
 
   test_wheels:
     name: Test wheels

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -32,7 +32,7 @@ jobs:
         python setup.py bdist_wheel
         ls dist/*
     - name: Save wheel
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: chama_${{ matrix.python-version }}_${{ matrix.os }}.whl
         path: dist/chama*

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -58,7 +58,7 @@ jobs:
     - name: Download wheel
       uses: actions/download-artifact@v4
         python -m pip install --upgrade pip
-        pip install wheel pyomo pandas numpy scipy
+        pip install wheel pyomo pandas<3.0 numpy>2.0 scipy
         pip install --no-index --pre --find-links=. chama
     - name: Import chama
       run: |

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -27,6 +27,13 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
+    - name: Build wheels
+      uses: pypa/cibuildwheel@v3.1.4
+      env:
+        #CIBW_ENVIRONMENT: 
+        CIBW_BUILD: cp310-* cp311-* cp312-* cp313-*
+        CIBW_SKIP: "*-win32 *-manylinux_i686 pp* *-musllinux*"
+        CIBW_REPAIR_WHEEL_COMMAND: '' # Skip repair step
     - name: Set up Python for twine verification
       uses: actions/setup-python@v5
       with:
@@ -69,7 +76,7 @@ jobs:
     - name: Install chama
       run: |
         python -m pip install --upgrade pip
-        pip install wheel pyomo pandas<3.0 numpy>2.0 scipy
+        pip install wheel pyomo pandas<3.0 numpy>2.0 scipy setuptools
         pip install --no-index --pre --find-links=. chama
     - name: Import chama
       run: |

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
         os: [ubuntu-latest]
     steps:
     - uses: actions/checkout@v2
@@ -48,7 +48,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
         os: [ubuntu-latest]
     steps:
     - name: Set up Python 
@@ -72,7 +72,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.10', '3.11', '3.12', '3.13']
         os: [ubuntu-latest]
     steps:
     - uses: actions/checkout@v2
@@ -111,7 +111,7 @@ jobs:
     - name: Set up Python 
       uses: actions/setup-python@v4
       with:
-        python-version: 3.11
+        python-version: 3.12
     - uses: actions/checkout@v2
     - name: Install coverage
       run: |
@@ -157,7 +157,7 @@ jobs:
     - name: Set up Python 
       uses: actions/setup-python@v4
       with:
-        python-version: 3.11
+        python-version: 3.12
     - uses: actions/checkout@v2
     - name: Install coverage
       run: |

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -22,9 +22,9 @@ jobs:
         python-version: ['3.10', '3.11', '3.12', '3.13']
         os: [ubuntu-latest]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -38,7 +38,7 @@ jobs:
         python setup.py bdist_wheel
         ls dist/*
     - name: Save wheel
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: chama_${{ matrix.python-version }}_${{ matrix.os }}.whl
         path: dist/chama*
@@ -52,15 +52,11 @@ jobs:
         os: [ubuntu-latest]
     steps:
     - name: Set up Python 
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Download wheel
-      uses: actions/download-artifact@v3
-      with:
-        name: chama_${{ matrix.python-version }}_${{ matrix.os }}.whl
-    - name: Install chama
-      run: |
+      uses: actions/download-artifact@v4
         python -m pip install --upgrade pip
         pip install wheel pyomo pandas numpy scipy
         pip install --no-index --pre --find-links=. chama
@@ -75,7 +71,7 @@ jobs:
         python-version: ['3.10', '3.11', '3.12', '3.13']
         os: [ubuntu-latest]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Setup conda
       uses: s-weigand/setup-conda@v1
       with:
@@ -99,7 +95,7 @@ jobs:
       env:
         COVERAGE_FILE: .coverage.${{ matrix.python-version }}.${{ matrix.os }}
     - name: Save coverage
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: coverage
         path: .coverage.${{ matrix.python-version }}.${{ matrix.os }}
@@ -109,10 +105,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Set up Python 
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: 3.12
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Install coverage
       run: |
         python -m pip install --upgrade pip
@@ -120,7 +116,7 @@ jobs:
         pip install coveralls
         python -m pip install -e .
     - name: Download coverage artifacts
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: coverage
     - name: Setup coverage and combine reports
@@ -139,12 +135,12 @@ jobs:
         coverage json --pretty-print
         coverage html --show-contexts
     - name: Save coverage JSON
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: coverage
         path: coverage.json
     - name: Save coverage html
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: coverage
         path: htmlcov
@@ -155,10 +151,10 @@ jobs:
     continue-on-error: true
     steps:
     - name: Set up Python 
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: 3.12
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Install coverage
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -35,7 +35,7 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: chama_${{ matrix.python-version }}_${{ matrix.os }}.whl
-        path: dist/*
+        path: dist/chama*
     - name: Set up Python for twine verification
       uses: actions/setup-python@v5
       with:
@@ -45,7 +45,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install twine
-        for wheel in ./dist/*.whl; do
+        for wheel in ./dist/chama*; do
           echo "Verifying wheel: $wheel"
           twine check "$wheel"
         done
@@ -53,7 +53,7 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: chama_${{ matrix.python-version }}_${{ matrix.os }}.whl
-        path: ./dist/*.whl
+        path: dist/chama*
 
   test_wheels:
     name: Test wheels

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -35,7 +35,7 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: chama_${{ matrix.python-version }}_${{ matrix.os }}.whl
-        path: dist/chama*
+        path: dist/*
     - name: Set up Python for twine verification
       uses: actions/setup-python@v5
       with:
@@ -45,7 +45,7 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install twine
-        for wheel in ./wheelhouse/*.whl; do
+        for wheel in ./dist/*.whl; do
           echo "Verifying wheel: $wheel"
           twine check "$wheel"
         done
@@ -53,7 +53,7 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: chama_${{ matrix.python-version }}_${{ matrix.os }}.whl
-        path: ./wheelhouse/*.whl
+        path: ./dist/*.whl
 
   test_wheels:
     name: Test wheels

--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -30,10 +30,7 @@ jobs:
     - name: Build wheels
       uses: pypa/cibuildwheel@v3.1.4
       env:
-        #CIBW_ENVIRONMENT: 
         CIBW_BUILD: cp310-* cp311-* cp312-* cp313-*
-        CIBW_SKIP: "*-win32 *-manylinux_i686 pp* *-musllinux*"
-        CIBW_REPAIR_WHEEL_COMMAND: '' # Skip repair step
     - name: Set up Python for twine verification
       uses: actions/setup-python@v5
       with:
@@ -47,7 +44,6 @@ jobs:
           echo "Verifying wheel: $wheel"
           twine check "$wheel"
         done
-
     - name: Upload wheels
       uses: actions/upload-artifact@v4
       with:
@@ -91,7 +87,7 @@ jobs:
       fail-fast: false
     steps:
     - uses: actions/checkout@v4
-    - name: Setup conda
+    - name: Setup conda ${{ matrix.python-version }}
       uses: s-weigand/setup-conda@v1
       with:
         update-conda: true

--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@ Organization
 
 Directories
   * chama - Python package
-  * ci - Travis CI requirements
   * documentation - User manual
-
+  * examples - Examples
+  
 Contact
 -------
    * Katherine Klise, Sandia National Laboratories, kaklise@sandia.gov

--- a/chama/__init__.py
+++ b/chama/__init__.py
@@ -4,7 +4,7 @@ from chama import impact
 from chama import optimize
 from chama import graphics
 
-__version__ = '0.3.0'
+__version__ = '0.4.0dev1'
 
 __copyright__ = """Copyright 2016 National Technology & Engineering 
     Solutions of Sandia, LLC (NTESS). Under the terms of Contract 

--- a/chama/tests/test_examples.py
+++ b/chama/tests/test_examples.py
@@ -2,6 +2,7 @@ import unittest
 import os
 import sys
 from subprocess import call
+import sys
 
 test_dir = os.path.dirname(os.path.abspath(__file__))
 examples_dir = os.path.join(test_dir, '..', '..', 'examples')
@@ -29,6 +30,9 @@ class TestExamples(unittest.TestCase):
         flag = 0
         failed_examples = []
         for f in example_files:
+            # Skip WNTR example due to deprecation of pkg_resources on py<3.11
+            if sys.version_info[0:2] <= (3, 11) and f == 'water_network_example.py':
+                continue
             tmp_flag = call([sys.executable, os.path.join(examples_dir, f)])
             print(f, tmp_flag)
             if tmp_flag == 1:

--- a/chama/tests/test_utils.py
+++ b/chama/tests/test_utils.py
@@ -57,7 +57,7 @@ class UtilsTests(unittest.TestCase):
         with self.assertRaises(TypeError):
             cu._df_columns_required('sample_data', df, {'Col1': object,
                                                         'Col2': [np.int64,
-                                                                 np.bool8],
+                                                                 bool],
                                                         'Col3': [np.int64,
                                                                  np.float64]})
 
@@ -94,7 +94,7 @@ class UtilsTests(unittest.TestCase):
         # test passing multiple types with incorrect types
         self.assertFalse(cu._df_columns_exist(df, {'Col1': object,
                                                    'Col2': [np.int64,
-                                                            np.bool8],
+                                                            bool],
                                                    'Col3': [np.int64,
                                                             np.float64]}))
 

--- a/documentation/installation.rst
+++ b/documentation/installation.rst
@@ -5,7 +5,7 @@
 Installation
 ======================================
 
-Chama requires Python (tested on 3.7-3.11) along with several Python package dependencies.  
+Chama requires Python (tested on 3.10, 3.11, 3.12, and 3.13) along with several Python package dependencies.  
 Information on installing and using Python can be found at 
 https://www.python.org/.  
 Python distributions, such as Anaconda, are recommended to manage the Python interface.  

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # Required
 pyomo
-pandas
+pandas<3.0
 numpy>2.0
 scipy
 setuptools

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # Required
 pyomo
 pandas
-numpy
+numpy>2.0
 scipy
 setuptools
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ AUTHOR = 'Chama developers'
 MAINTAINER_EMAIL = 'kaklise@sandia.gov'
 LICENSE = 'Revised BSD'
 URL = 'https://github.com/sandialabs/chama'
-DEPENDENCIES = ['pyomo', 'pandas', 'numpy>2.0', 'scipy']
+DEPENDENCIES = ['pyomo', 'pandas<3.0', 'numpy>2.0', 'scipy']
 
 # use README file as the long description
 file_dir = os.path.abspath(os.path.dirname(__file__))

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ AUTHOR = 'Chama developers'
 MAINTAINER_EMAIL = 'kaklise@sandia.gov'
 LICENSE = 'Revised BSD'
 URL = 'https://github.com/sandialabs/chama'
-DEPENDENCIES = ['pyomo', 'pandas', 'numpy', 'scipy']
+DEPENDENCIES = ['pyomo', 'pandas', 'numpy>2.0', 'scipy']
 
 # use README file as the long description
 file_dir = os.path.abspath(os.path.dirname(__file__))


### PR DESCRIPTION
The following PR includes the following updates:
- Updated GitHub Action versioning and format
- Dropped Python 3.9 and added Python 3.13 to the tests
- Limited Pandas version to <3.0 and added Numpy>2.0
- Skipped testing of WNTR example on Python<3.11 due to deprecation of pkg_resources
- Resolved np.bool8 error